### PR TITLE
Use yaml.safe_load() instead of yaml.load()

### DIFF
--- a/csgomenumaker/loader/loader.py
+++ b/csgomenumaker/loader/loader.py
@@ -18,9 +18,9 @@ class Loader(misc.Loggable):
 
     def __init__(self, infile, file=True, example=False):
         if file:
-            self.options = yaml.load(open(infile, "r"))
+            self.options = yaml.safe_load(open(infile, "r"))
         else:
-            self.options = yaml.load(infile)
+            self.options = yaml.safe_load(infile)
         self.example = example
         self.root = command.Root()
         self.root.config = self


### PR DESCRIPTION
Using `yaml.load()` allows to execute arbitrary system commands if config files from untrusted sources are loaded. Here is an example config file:

```yaml                       
tree:
    Master Volume: !!python/object/apply:os.system ["id"]
```
Loading this config file will execute the `id` command:
```
➜  csgo-menu-maker-takeshixx git:(master) ✗ env/bin/python -m csgomenumaker testfile
uid=1001(takeshix) gid=1001(takeshix) groups=1001(takeshix)
tree: type=Flex,default=None
        type: type=String,default=...

mm.Folder.**object**.tree:
        Error: Wrong type for Master Volume! Need 'dict' or 'str', got 'str'.
        ... in:
        {'tree': {'Master Volume': 0}, 'up': 'uparrow', 'down': 'downarrow', 'left': 'leftarrow', 'right': 'rightarrow', 'fire': 'enter', 'back': '\\', 'enable': 'alt', 'keybinds': {...}, 'updown': 'buttons/button22', 'leftright': 'ui/menu_accept', 'forward': 'ui/menu_focus', 'backward': 'ui/menu_back', 'volume': 0.8, 'sounds': {...}, 'name': 'Folder', 'desc': 'A folder to organize components in.'}
```
Using `yaml.safe_load()` instead will prevent loading arbitrary Python objects.