### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/csgomenumaker/docgen/docgen.py
+++ b/csgomenumaker/docgen/docgen.py
@@ -97,7 +97,7 @@ class DocGen(misc.Loggable):
         parts = path.parts
         out_path = list(parts)
         p = out_path[0]
-        while p is not "csgomenumaker":
+        while p != "csgomenumaker":
             out_path.pop(0)
             p = out_path[0]
 


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/citrusCS/csgo-menu-maker on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./csgomenumaker/docgen/docgen.py:100:15: F632 use ==/!= to compare str, bytes, and int literals
        while p is not "csgomenumaker":
              ^
./csgomenumaker/param/number.py:91:19: F823 local variable 'max' defined as a builtin referenced before assignment
            min = max-10 if "min" not in self.kwargs else self.kwargs["min"]
                  ^
1     F632 use ==/!= to compare str, bytes, and int literals
1     F823 local variable 'max' defined as a builtin referenced before assignment
2
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree